### PR TITLE
Make pages mobile friendly

### DIFF
--- a/SocketIOServer/public/countdown/countdown.css
+++ b/SocketIOServer/public/countdown/countdown.css
@@ -1,0 +1,29 @@
+body {
+    padding: 20px;
+}
+#container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+img {
+    width: 30px;
+    height: 30px;
+    object-fit: cover;
+    padding: 0 10px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    img {
+        width: 20px;
+        height: 20px;
+        padding: 0 6px;
+    }
+    h1 {
+        font-size: 55px;
+    }
+}

--- a/SocketIOServer/public/countdown/countdown.html
+++ b/SocketIOServer/public/countdown/countdown.html
@@ -1,33 +1,15 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
+    <link rel="stylesheet" type="text/css" href="countdown.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <style>
-        #container {
-            width: 100vw;
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-content: center;
-            align-items: flex-end;
-            flex-wrap: wrap;
-        }
-        img {
-            width: 30px;
-            height: 30px;
-            object-fit: cover;
-            padding: 0 10px;
-        }
-    </style>
 </head>
-<script src="/socket.io/socket.io.js"></script>
-<script>
-    var socket = io();
-</script>
+
 
 <body>
     <div id="container">
@@ -36,6 +18,7 @@
         <img src="../Resources/heart-outline.png" alt="A red heart">
         <img src="../Resources/heart-outline.png" alt="A red heart">
     </div>
+    <script src="/socket.io/socket.io.js"></script>
     <script src="countdown.js"></script>
 </body>
 </html>

--- a/SocketIOServer/public/index.css
+++ b/SocketIOServer/public/index.css
@@ -14,22 +14,40 @@ body {
     width: 100vw;
 }
 
-#logo {
+img {
     height: 200px;
+}
+
+#logo {
     margin-bottom: 40px;
 }
 
 #rightHearts {
-    height: 200px;
     position: absolute;
     right: 50px;
     top: 50px;
 }
 
 #leftHearts {
-    height: 200px;
     transform: scaleX(-1);
     position: absolute;
     left: 50px;
     bottom: 50px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    img {
+        height: 100px;
+    }
+    #logo {
+        margin-bottom: 10px;
+    }
+    #rightHearts {
+        right: 5px;
+        top: 5px;
+    }
+    #leftHearts {
+        left: 5px;
+        bottom: 5px;
+    }
 }

--- a/SocketIOServer/public/index.html
+++ b/SocketIOServer/public/index.html
@@ -1,19 +1,14 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>RC:OS</title>
+        <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="./shared.css">
         <link rel="stylesheet" type="text/css" href="./index.css">
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     </head>
-    <script src="/socket.io/socket.io.js"></script>
-    <script>
-    var socket = io();
-    
-    
-    </script>
     <body>
         <div id="container">
             <img id="rightHearts" alt="Three hearts as decoration" src="./Resources/hearts.png"/>
@@ -24,7 +19,6 @@
             </div>
             <img id="leftHearts" alt="Three hearts as decoration" src="./Resources/hearts.png"/>
         </div>
-
-
+        <script src="/socket.io/socket.io.js"></script>
     </body>
 </html>

--- a/SocketIOServer/public/lobby/lobby.css
+++ b/SocketIOServer/public/lobby/lobby.css
@@ -1,14 +1,19 @@
 #container {
-    padding-top: 80px;
-    width: 100vw;
+    /*width: 100vw;*/
     height: 100vh;
+    overflow: hidden;
+}
+
+#container h1{
+    margin-top: 80px;
+    margin-bottom: 32px;
 }
 
 #scrollContainer {
     overflow: hidden;
     position: relative;
     width: 50%;
-    height: 100vh;
+    height: 100%;
     margin: auto;
 }
 
@@ -17,7 +22,7 @@
     width: 100%;
     height: 100%;
     top: 100%;
-    animation: 15s scrollContainer 0s linear infinite;
+    animation: 30s scrollContainer 0s linear infinite;
 }
 
 @keyframes scrollContainer {
@@ -35,11 +40,12 @@
 
 .playerCard {
     display: block;
-    float: left;  /* to have the player card be left aligned, set float: left; clear: left; */
+    float: left;  /* to have the player card be left aligned, set float: left; clear: right; */
     clear: left;
     border: 5px solid #D6202A;
     border-radius: 36px;
     width: fit-content;
+    height: fit-content;
     text-align: center;
     margin: 10px 0;
 }
@@ -51,4 +57,50 @@
     border-bottom: 2px solid #D6202A;
     border-top-left-radius: 36px;
     border-top-right-radius: 36px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #scrollContainer {
+        width: 80%;
+    }
+    .playerCard {
+        border-width: 2px;
+        border-radius: 18px;
+    }
+    .userImage {
+        width: 100px;
+        height: 100px;
+        border-top-left-radius: 18px;
+        border-top-right-radius: 18px;
+    }
+}
+
+@media (max-height: 425px) {
+    #scrollContainer {
+        overflow: hidden;
+        position: relative;
+        width: 100%;
+        height: 50%;
+        margin: auto;
+    }
+
+    #players {
+        display: flex;
+        flex-direction: row;
+        gap: 60px;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        animation: 30s scrollContainer 0s linear infinite;
+    }
+
+    @keyframes scrollContainer {
+        from {
+            left: 100%;
+        }
+        to {
+            left: -300%;
+        }
+    }
 }

--- a/SocketIOServer/public/lobby/lobby.html
+++ b/SocketIOServer/public/lobby/lobby.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
     <link rel="stylesheet" type="text/css" href="./lobby.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/SocketIOServer/public/lobbyCode/index.css
+++ b/SocketIOServer/public/lobbyCode/index.css
@@ -1,5 +1,10 @@
 #container {
-    padding-top: 80px;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    flex-wrap: wrap;
     text-align: center;
 }
 
@@ -29,4 +34,17 @@
 
 .code:focus {
     background-color: #ffb9c1;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #codeGroup {
+        gap: 4px;
+    }
+    .code {
+        font-size: 32px;
+        height: 68px;
+        width: 48px;
+        border-width: 2px;
+        border-radius: 18px;
+    }
 }

--- a/SocketIOServer/public/lobbyCode/index.html
+++ b/SocketIOServer/public/lobbyCode/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
     <link rel="stylesheet" type="text/css" href="./index.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,24 +13,26 @@
     <link href="https://fonts.googleapis.com/css2?family=Anta&display=swap" rel="stylesheet">
 </head>
 <body>
-<div id="container">
-    <h1>Game Code</h1>
-    <h3>Please enter your game code</h3>
-    <div>
-        <form id="codeForm">
-            <div id="codeGroup">
-                <input type="text" maxlength="1" class="code">
-                <input type="text" maxlength="1" class="code">
-                <input type="text" maxlength="1" class="code">
-                <input type="text" maxlength="1" class="code">
-                <input type="text" maxlength="1" class="code">
+    <div id="container">
+        <div>
+            <h1>Game Code</h1>
+            <h3>Please enter your game code</h3>
+            <div>
+                <form id="codeForm">
+                    <div id="codeGroup">
+                        <input type="text" maxlength="1" class="code">
+                        <input type="text" maxlength="1" class="code">
+                        <input type="text" maxlength="1" class="code">
+                        <input type="text" maxlength="1" class="code">
+                        <input type="text" maxlength="1" class="code">
+                    </div>
+                    <br>
+                    <button type="submit">Submit</button>
+                </form>
             </div>
-            <br>
-            <button type="submit">Submit</button>
-        </form>
+        </div>
     </div>
-</div>
-<script src="/socket.io/socket.io.js"></script>
-<script src="./index.js"></script>
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="./index.js"></script>
 </body>
 </html>

--- a/SocketIOServer/public/postGame/postGame.css
+++ b/SocketIOServer/public/postGame/postGame.css
@@ -1,0 +1,17 @@
+#container {
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 60px;
+    background-image: url("../Resources/confetti.png");
+}
+#container h1 {
+    padding: 0 20px;
+}
+button {
+    width: 100vw;
+}
+

--- a/SocketIOServer/public/postGame/postGame.html
+++ b/SocketIOServer/public/postGame/postGame.html
@@ -1,26 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
+    <link rel="stylesheet" type="text/css" href="postGame.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <style>
-        #container {
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-content: center;
-            flex-wrap: wrap;
-            flex-direction: column;
-            gap: 60px;
-            background-image: url("../Resources/confetti.png");
-        }
-        button {
-            width: 100vw;
-        }
-    </style>
 </head>
 <body>
 <div id="container">

--- a/SocketIOServer/public/presenting/presenting.css
+++ b/SocketIOServer/public/presenting/presenting.css
@@ -1,0 +1,19 @@
+#container {
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 80px;
+}
+
+#container h1 {
+    padding: 0 20px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #container {
+        gap: 40px;
+    }
+}

--- a/SocketIOServer/public/presenting/presenting.html
+++ b/SocketIOServer/public/presenting/presenting.html
@@ -1,22 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
+    <link rel="stylesheet" type="text/css" href="presenting.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <style>
-        #container {
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-content: center;
-            flex-wrap: wrap;
-            flex-direction: column;
-            gap: 80px;
-        }
-    </style>
 </head>
 
 <body>

--- a/SocketIOServer/public/profileCreation/profile_creation.css
+++ b/SocketIOServer/public/profileCreation/profile_creation.css
@@ -21,7 +21,12 @@ input:focus {
 }
 
 #outerContainer {
-    padding-top: 80px;
+    display: flex;
+    height: 100vh;
+    justify-content: center;
+    flex-direction: column;
+    gap: 30px;
+    margin-top: -30px;
 }
 
 #container {
@@ -29,6 +34,7 @@ input:focus {
     justify-content: center;
     flex-direction: row;
     gap: 100px;
+    flex-wrap: wrap;
 }
 
 #profileForm {
@@ -40,6 +46,8 @@ input:focus {
 #imageContainer {
     position: relative;
     border: 5px solid #D6202A;
+    width: 400px;
+    height: 300px;
 }
 
 #imageContainer:hover #buttons {
@@ -52,12 +60,21 @@ input:focus {
     opacity: 0.3;
 }
 
+#image {
+    width: 100%;
+    height: 100%;
+}
+
 #buttons {
     display: none;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+}
+
+#buttons img {
+    width: 68px;
 }
 
 #uploadLabel:hover img{
@@ -112,4 +129,37 @@ input:focus {
     position: absolute;
     bottom: 20px;
     right: 40px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #container {
+        gap: 30px;
+    }
+    #imageContainer {
+        width: 200px;
+        height: 150px;
+    }
+    #imageContainer:hover #buttons {
+        gap: 8px;
+    }
+    #buttons img{
+        width: 52px;
+    }
+    #profileForm form input{
+        width: 250px;
+        height: 50px;
+    }
+    label {
+        font-size: 20px;
+    }
+    input {
+        font-size: 20px;
+        padding: 5px;
+        border-width: 2px;
+        border-radius: 18px;
+    }
+    #next {
+        bottom: 20px;
+        right: 30px;
+    }
 }

--- a/SocketIOServer/public/profileCreation/profile_creation.html
+++ b/SocketIOServer/public/profileCreation/profile_creation.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <title>Profile_Creation</title>
+        <meta name="viewport" content="width=device-width" />
         <link rel="stylesheet" type="text/css" href="../shared.css">
         <link rel="stylesheet" type="text/css" href="./profile_creation.css">
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -17,14 +18,13 @@
             <form id="user_profile">
                 <div id="container">
                     <div id="imageContainer">
-                        <img src="../Resources/user-icon.png" alt="An icon representing a generic user." id="image" width="400px" height="300px">
+                        <img src="../Resources/user-icon.png" alt="An icon representing a generic user." id="image">
                         <div id="buttons">
-                            <button type="button" id="libraryButton"><img src="../Resources/image-icon.png" alt="An image icon" width="68px" ></button>
+                            <button type="button" id="libraryButton"><img src="../Resources/image-icon.png" alt="An image icon"></button>
                             <form>
                                 <label for="upload" id="uploadLabel"><img src="../Resources/upload-icon.png" alt="An upload icon."></label>
                                 <input type="file" id="upload" accept="image/*" hidden>
                             </form>
-
                         </div>
 
                     </div>
@@ -36,9 +36,9 @@
                         </form>
                     </div>
                 </div>
-            </div>
+            </form>
             <button id="next">Next</button>
-        </form>
+        </div>
         <div id="modal">
             <div id="modal-content">
                 <span id="close">&times;</span>

--- a/SocketIOServer/public/prompt/prompt.css
+++ b/SocketIOServer/public/prompt/prompt.css
@@ -17,9 +17,10 @@
     padding: 10px 0 0 20px;
 }
 
-#prompt {
-    width: 90%;
-    margin: auto;
+.prompt {
+    padding: 10px 40px;
+    text-align: center;
+    overflow-wrap: break-word;
 }
 
 #answers {
@@ -34,8 +35,8 @@
 
 .answerCard {
     width: 25%;
-    height: 150px;
-    overflow: auto;
+    height: 120px;
+    overflow-wrap: break-word;
     border: 5px solid #D6202A;
     border-radius: 36px;
     padding: 10px;
@@ -44,16 +45,11 @@
     font-size: 16px;
     font-weight: 300;
     color: #000000;
+
 }
 
 .answerCard:hover {
     transform: scale(1.1);
-}
-
-#next {
-    position: absolute;
-    bottom: 50px;
-    right: 80px;
 }
 
 .timerBar {
@@ -78,5 +74,45 @@
     }
     to {
         transform: scaleX(1);
+    }
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #header img {
+        height: 48px;
+    }
+    #timer {
+        font-size: 20px;
+    }
+    #answers {
+        gap: 12px;
+    }
+    .answerCard {
+        border-width: 2px;
+        border-radius: 18px;
+        font-size: 12px;
+        padding: 5px;
+    }
+}
+
+@media (max-width: 425px) {
+    #questionContainer {
+        margin-top: 40px;
+    }
+    .prompt {
+        padding: 10px 40px 30px 40px;
+    }
+    .answerCard {
+        width: 45%;
+        height: 100px;
+    }
+}
+
+@media (max-height: 425px) {
+    .answerCard {
+        height: 72px;
+    }
+    .timerBar {
+        bottom: 8px;
     }
 }

--- a/SocketIOServer/public/prompt/prompt.html
+++ b/SocketIOServer/public/prompt/prompt.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
     <link rel="stylesheet" type="text/css" href="./prompt.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -22,6 +23,5 @@
     </div>
     <script src="/socket.io/socket.io.js"></script>
     <script src="prompt.js"></script>
-
 </body>
 </html>

--- a/SocketIOServer/public/prompt/prompt.js
+++ b/SocketIOServer/public/prompt/prompt.js
@@ -49,6 +49,7 @@ socket.on('on-send-prompt',(question, num) =>{
 
     const promptElement = document.createElement('h4');
     promptElement.textContent = `${question}`;
+    promptElement.className = 'prompt';
 
     questionContainer.appendChild(questionElement);
     questionContainer.appendChild(promptElement);

--- a/SocketIOServer/public/shared.css
+++ b/SocketIOServer/public/shared.css
@@ -54,3 +54,18 @@ button:hover {
     cursor: pointer;
     transform: scale(1.2);
 }
+
+@media (max-width: 425px) or (max-height: 425px) {
+    h1 {
+        font-size: 40px;
+    }
+    h3 {
+        font-size: 16px;
+    }
+    h4 {
+        font-size: 14px;
+    }
+    button {
+        font-size: 1em;
+    }
+}

--- a/SocketIOServer/public/swipe/swipe.css
+++ b/SocketIOServer/public/swipe/swipe.css
@@ -1,0 +1,25 @@
+#container {
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+}
+#rightHearts {
+    height: 200px;
+    transform: scaleX(-1);
+}
+
+#leftHearts {
+    height: 200px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #container h1 {
+        font-size: 32px;
+    }
+    #rightHearts, #leftHearts {
+        height: 24px;
+    }
+}

--- a/SocketIOServer/public/swipe/swipe.html
+++ b/SocketIOServer/public/swipe/swipe.html
@@ -1,30 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
+    <link rel="stylesheet" type="text/css" href="swipe.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <style>
-        #container {
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-content: center;
-            align-items: center;
-            flex-wrap: wrap;
-        }
-        #rightHearts {
-            height: 200px;
-            transform: scaleX(-1);
-        }
-
-        #leftHearts {
-            height: 200px;
-        }
-    </style>
-
 </head>
 <body>
 <div id="container">

--- a/SocketIOServer/public/voting/voting.css
+++ b/SocketIOServer/public/voting/voting.css
@@ -2,6 +2,19 @@
     padding-top: 80px;
     text-align: center;
 }
+h1 {
+    padding: 0 10px;
+}
+#name {
+    color: black;
+}
+#buttons {
+    display: flex;
+    justify-content: center;
+    flex-direction: row;
+    gap: 48px;
+    margin-top: 10px;
+}
 .votingButton {
     border: 5px solid #D6202A;
     border-radius: 36px;
@@ -9,6 +22,11 @@
 }
 .votingButton:hover {
     transform: scale(1.1);
+}
+#submit {
+    position: absolute;
+    bottom: 50px;
+    right: 80px;
 }
 #confirmation {
     position: absolute;
@@ -30,5 +48,34 @@
     }
     to {
         opacity: 0;
+    }
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    #container {
+        padding-top: 140px;
+    }
+    #name {
+        font-size: 60px;
+    }
+    #buttons {
+        gap: 20px;
+    }
+    .votingButton {
+        border-width: 2px;
+        border-radius: 18px;
+    }
+    .votingButton img {
+        width: 72px;
+    }
+    #submit {
+        bottom: 20px;
+        right: 30px;
+    }
+}
+
+@media (max-height: 425px) {
+    #container {
+        padding-top: 40px;
     }
 }

--- a/SocketIOServer/public/voting/voting.html
+++ b/SocketIOServer/public/voting/voting.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
     <link rel="stylesheet" type="text/css" href="./voting.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -12,8 +13,8 @@
 <div id="container">
     <div id="voteContainer">
         <h1>Cast your vote for</h1>
-        <h1 id ="name" style="color: black">User</h1>
-        <div style="display: flex; justify-content: center; flex-direction: row; gap: 50px; margin-top: 20px;">
+        <h1 id ="name">User</h1>
+        <div id="buttons">
             <button id="like" class="votingButton" data-selected="false"><img src="../Resources/heart-filled.png" alt="Heart icon." width="160px"></button>
             <button id="dislike" class="votingButton" data-selected="false"><img src="../Resources/thumbs-down.png" alt="Downwards thumb for dislike." width="160px"></button>
         </div>

--- a/SocketIOServer/public/waitingForPlayers/waiting.css
+++ b/SocketIOServer/public/waitingForPlayers/waiting.css
@@ -1,0 +1,22 @@
+#container {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-content: center;
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+img {
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+    padding: 0 10px;
+}
+
+@media (max-width: 425px) or (max-height: 425px) {
+    img {
+        width: 48px;
+        height: 48px;
+    }
+}

--- a/SocketIOServer/public/waitingForPlayers/waiting.html
+++ b/SocketIOServer/public/waitingForPlayers/waiting.html
@@ -1,28 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>RC:OS</title>
+    <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" type="text/css" href="../shared.css">
+    <link rel="stylesheet" type="text/css" href="waiting.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Prompt:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
-    <style>
-        #container {
-            width: 100vw;
-            height: 100vh;
-            display: flex;
-            justify-content: center;
-            align-content: center;
-            align-items: flex-end;
-            flex-wrap: wrap;
-        }
-        img {
-            width: 100px;
-            height: 100px;
-            object-fit: cover;
-            padding: 0 10px;
-        }
-    </style>
 </head>
 
 <body>


### PR DESCRIPTION
Added necessary CSS modifications using media rule and moved some styling from HTML to CSS files. The media breakpoints are based on the Google Developer Tool settings, where Mobile L is 425px wide and Mobile S is 320px. The design of the websites mostly stayed the same, except for the lobby page where if the phone is rotated horizontally the player names go sideways instead of vertically.