### PR TITLE
Add styling for error messages

### DIFF
--- a/SocketIOServer/public/lobbyCode/index.css
+++ b/SocketIOServer/public/lobbyCode/index.css
@@ -38,7 +38,7 @@
 }
 
 #response {
-    display: none;
+    display: block;
     width: fit-content;
     color: #D6202A;
     font-weight: 400;

--- a/SocketIOServer/public/lobbyCode/index.css
+++ b/SocketIOServer/public/lobbyCode/index.css
@@ -37,6 +37,16 @@
     background-color: #ffb9c1;
 }
 
+#response {
+    display: none;
+    width: fit-content;
+    color: #D6202A;
+    font-weight: 400;
+    text-transform: uppercase;
+    padding: 10px;
+    margin: 0 auto;
+}
+
 @media (max-width: 425px) or (max-height: 425px) {
     #codeGroup {
         gap: 4px;

--- a/SocketIOServer/public/lobbyCode/index.html
+++ b/SocketIOServer/public/lobbyCode/index.html
@@ -17,6 +17,7 @@
         <div>
             <h1>Game Code</h1>
             <h3>Please enter your game code</h3>
+            <p id="response"></p>
             <div>
                 <form id="codeForm">
                     <div id="codeGroup">

--- a/SocketIOServer/public/lobbyCode/index.js
+++ b/SocketIOServer/public/lobbyCode/index.js
@@ -77,7 +77,9 @@ socket.on('join-lobby-success', function() {
 // Listen for the 'lobbyConnection' event from the server
 socket.on('join-lobby-fail-dne', function(){
     //When lobby doesn't exist prints that the lobby doesn't exist
-    document.getElementById('response').textContent = "Lobby does not exist.";
+    const error = document.getElementById('response');
+    error.textContent = "Lobby does not exist. Please try again.";
+    error.style.display='block';
 });
 
 

--- a/SocketIOServer/public/lobbyCode/index.js
+++ b/SocketIOServer/public/lobbyCode/index.js
@@ -77,9 +77,7 @@ socket.on('join-lobby-success', function() {
 // Listen for the 'lobbyConnection' event from the server
 socket.on('join-lobby-fail-dne', function(){
     //When lobby doesn't exist prints that the lobby doesn't exist
-    const error = document.getElementById('response');
-    error.textContent = "Lobby does not exist. Please try again.";
-    error.style.display='block';
+    document.getElementById('response').textContent = "Lobby does not exist. Please try again.";
 });
 
 

--- a/SocketIOServer/public/profileCreation/profile_creation.css
+++ b/SocketIOServer/public/profileCreation/profile_creation.css
@@ -125,6 +125,16 @@ input:focus {
     cursor: pointer;
 }
 
+#errorMessage {
+    display: block;
+    width: fit-content;
+    color: #D6202A;
+    font-weight: 400;
+    text-transform: uppercase;
+    padding: 10px;
+    margin: 0 auto;
+}
+
 #continueButton {
     position: absolute;
     bottom: 20px;

--- a/SocketIOServer/public/shared.css
+++ b/SocketIOServer/public/shared.css
@@ -65,6 +65,9 @@ button:hover {
     h4 {
         font-size: 14px;
     }
+    p {
+        font-size: 12px;
+    }
     button {
         font-size: 1em;
     }


### PR DESCRIPTION
Added styling for error messages on profile creation page and lobby code page.

Possible Improvements:
- Could create a more custom display for the error where it points to where an input is required
- Could focus on the code input on the lobby code page when there is an error

![image](https://github.com/user-attachments/assets/a33da275-dc38-4fc6-9f64-7a36033b440c)

![image](https://github.com/user-attachments/assets/9b78cd1a-8e7c-492b-ae4e-80a3d750a236)

