### PR TITLE
Fix player card in lobby

### DIFF
--- a/SocketIOServer/public/lobby/lobby.css
+++ b/SocketIOServer/public/lobby/lobby.css
@@ -1,5 +1,4 @@
 #container {
-    /*width: 100vw;*/
     height: 100vh;
     overflow: hidden;
 }
@@ -34,10 +33,6 @@
     }
 }
 
-#players:hover {
-    animation-play-state: paused;
-}
-
 .playerCard {
     display: block;
     float: left;  /* to have the player card be left aligned, set float: left; clear: right; */
@@ -51,12 +46,12 @@
 }
 
 .userImage{
-    width: 150px;
-    height: 150px;
+    width: 200px;
+    height: 200px;
     object-fit: cover;
     border-bottom: 2px solid #D6202A;
-    border-top-left-radius: 36px;
-    border-top-right-radius: 36px;
+    border-top-left-radius: 30px;
+    border-top-right-radius: 30px;
 }
 
 @media (max-width: 425px) or (max-height: 425px) {
@@ -70,8 +65,8 @@
     .userImage {
         width: 100px;
         height: 100px;
-        border-top-left-radius: 18px;
-        border-top-right-radius: 18px;
+        border-top-left-radius: 16px;
+        border-top-right-radius: 16px;
     }
 }
 

--- a/SocketIOServer/public/lobby/lobby.js
+++ b/SocketIOServer/public/lobby/lobby.js
@@ -28,7 +28,6 @@ socket.on('updated-players', (names, b64) => {
         imageElement.src = `data:image/png;base64,${base64}`;
         imageElement.alt = `${name}'s image`;
         imageElement.className = 'userImage'
-        imageElement.style.width = '200px'; 
 
         // User name
         let nameElement = document.createElement('h3');


### PR DESCRIPTION
Fixed issue where there was a gap between the player image and the border in the lobby. Also removed where hovering over a section of the lobby pauses the animation.

![image](https://github.com/user-attachments/assets/5d649c8d-7aae-4295-84f9-0330a42ca73e)
