### PR TITLE
Update styling for player cards in lobby

### DIFF
--- a/SocketIOServer/public/lobby/lobby.css
+++ b/SocketIOServer/public/lobby/lobby.css
@@ -36,7 +36,7 @@
 .playerCard {
     display: block;
     float: left;  /* to have the player card be left aligned, set float: left; clear: right; */
-    clear: left;
+    clear: right;
     border: 5px solid #D6202A;
     border-radius: 36px;
     width: fit-content;

--- a/SocketIOServer/public/lobby/lobby.js
+++ b/SocketIOServer/public/lobby/lobby.js
@@ -22,6 +22,10 @@ socket.on('updated-players', (names, b64) => {
         
         const playerCard = document.createElement('div');
         playerCard.className = 'playerCard';
+        if (i % 2 !== 0) {
+            playerCard.style.float = 'right';
+            playerCard.style.clear = 'left';
+        }
         
         // User image
         let imageElement = document.createElement('img');


### PR DESCRIPTION
Fixed issue where player cards only lined up on the left side of the page rather than alternating left and right.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/71264dc6-7dee-4388-a1bc-3a909757fd3c">
